### PR TITLE
Customizable port

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,8 @@ which will fail when running for the first time.
 
 4. Optional: To customize the running port, set the env var `TEAMAPPS_EXAMPLES_PORT` 
 to the port of your liking in the run config. 
+
+## Icon usage in examples
+
+Icons can be used in examples by using constants on the MaterialIcon class. 
+The icon names can be found here: https://www.iconfu.com/main#/icons/5/1

--- a/README.md
+++ b/README.md
@@ -1,0 +1,18 @@
+# Teamapps Examples 
+
+This repository contains java example code for all components, concepts and tutorials for the teamapps-framework. 
+
+
+## Run Dev Environment in IntelliJ IDEA
+
+1. Run the class `RunExample` by opening the class, 
+clicking the green arrow before the class name 
+and choosing 'Run...'. This generates an IntelliJ IDEA run configuration, 
+which will fail when running for the first time. 
+
+2. Right click on the `<Component>Example` class you want to run and choose `Copy reference`. 
+
+3. Edit the `RunExample` run config and paste the class reference into `program arguments`. 
+
+4. Optional: To customize the running port, set the env var `TEAMAPPS_EXAMPLES_PORT` 
+to the port of your liking in the run config. 

--- a/src/main/java/org/teamapps/examples/AbstractRunExample.java
+++ b/src/main/java/org/teamapps/examples/AbstractRunExample.java
@@ -29,6 +29,12 @@ public abstract class AbstractRunExample {
 		put(Table.class, 500);
 	}};
 
+	int port;
+
+	AbstractRunExample(int port) {
+		this.port = port;
+	}
+
 	public void runServerWithExamples(Object example) {
 		runServerWithExamples(new Object[]{example});
 	}
@@ -65,7 +71,7 @@ public abstract class AbstractRunExample {
 				}
 				return verticalLayout;
 			}, Color.WHITE);
-			new TeamAppsJettyEmbeddedServer(controller, Files.createTempDir()).start();
+			new TeamAppsJettyEmbeddedServer(controller, Files.createTempDir(), port).start();
 		} catch (Exception e) {
 			e.printStackTrace();
 		}

--- a/src/main/java/org/teamapps/examples/RunExample.java
+++ b/src/main/java/org/teamapps/examples/RunExample.java
@@ -6,11 +6,11 @@ import java.util.Map;
 
 public class RunExample extends AbstractRunExample {
 
-	public RunExample(int port) {
+	private RunExample(int port) {
 		super(port);
 	}
 
-	public static int getPort() {
+	private static int getPort() {
 		Map<String, String> env = System.getenv();
 		int defaultPort = 8080;
 		String port = env.get("TEAMAPPS_EXAMPLES_PORT");

--- a/src/main/java/org/teamapps/examples/RunExample.java
+++ b/src/main/java/org/teamapps/examples/RunExample.java
@@ -2,10 +2,32 @@ package org.teamapps.examples;
 
 
 import java.util.Arrays;
+import java.util.Map;
 
 public class RunExample extends AbstractRunExample {
+
+	public RunExample(int port) {
+		super(port);
+	}
+
+	public static int getPort() {
+		Map<String, String> env = System.getenv();
+		int defaultPort = 8080;
+		String port = env.get("TEAMAPPS_EXAMPLES_PORT");
+		if (port == null) {
+			return defaultPort;
+		}
+
+		try {
+			return Integer.parseInt(port);
+		} catch (NumberFormatException e) {
+			System.err.println("Invalid port in TEAMAPPS_EXAMPLE_PORT env!");
+			return defaultPort;
+		}
+	}
+
 	public static void main(String[] args) {
-		RunExample run = new RunExample();
+		RunExample run = new RunExample(getPort());
 		if (args.length > 0) {
 			Object[] examples = Arrays.stream(args)
 					.map(className -> {
@@ -22,4 +44,5 @@ public class RunExample extends AbstractRunExample {
 			run.runServerWithExamples(/* insert your example instances here */);
 		}
 	}
+
 }


### PR DESCRIPTION
# Changes

- adds readme with usage information

- allows the jetty port for RunExample to be changed from the outside via setting the `TEAMAPPS_EXAMPLES_PORT` env var